### PR TITLE
feat: Add monitoring.viewer role to gather metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cloudresourcemanager.googleapis.com
 | [google_logging_project_sink.lacework_project_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_organization_iam_audit_config.organization_audit_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_audit_config) | resource |
 | [google_project_iam_audit_config.project_audit_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_audit_config) | resource |
+| [google_project_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_pubsub_subscription.lacework_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_binding.lacework](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |

--- a/examples/organization-level-gke-audit/README.md
+++ b/examples/organization-level-gke-audit/README.md
@@ -16,7 +16,7 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_gke_audit_log" {
-  source           = "lacework/audit-log/gcp"
+  source           = "lacework/gke-audit-log/gcp"
   version          = "~> 0.1"
   integration_type = "ORGANIZATION"
   project_id       = "example-project-123"

--- a/examples/project-level-gke-audit/README.md
+++ b/examples/project-level-gke-audit/README.md
@@ -16,7 +16,7 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_project_level_gke_audit" {
-  source           = "lacework/audit-log/gcp"
+  source           = "lacework/gke-audit-log/gcp"
   version          = "~> 0.1"
   integration_type = "PROJECT"
   project_id       = "example-project-123"

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,12 @@ resource "google_organization_iam_audit_config" "organization_audit_logs" {
   }
 }
 
+resource "google_project_iam_member" "for_lacework_service_account" {
+  project = local.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${local.service_account_json_key.client_email}"
+}
+
 # wait for X seconds for things to settle down in the GCP side
 # before trying to create the Lacework external integration
 resource "time_sleep" "wait_time" {
@@ -141,7 +147,8 @@ resource "time_sleep" "wait_time" {
     google_pubsub_subscription_iam_binding.lacework,
     module.lacework_gke_svc_account,
     google_project_iam_audit_config.project_audit_logs,
-    google_organization_iam_audit_config.organization_audit_logs
+    google_organization_iam_audit_config.organization_audit_logs,
+    google_project_iam_member.for_lacework_service_account
   ]
 }
 


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>


## Summary

It appears that the ingest team requires to be able to make a `monitoring.timeSeries.list` call. In order to provide the relevant permission we need to add an additional role. The google role with the least number of permissions was identified as `roles/monitoring.viewer`

## How did you test this change?



## Issue

https://lacework.atlassian.net/browse/RAIN-36524
