### PR TITLE
feat(GcpGkeAudit): Addition of exclusion filters for extraneous log entries

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,31 @@ resource "google_logging_project_sink" "lacework_project_sink" {
   unique_writer_identity = true
 
   filter     = local.log_filter
+
+  exclusions {
+    name = "livezexclusion"
+    description = "Exclude livez logs"
+    filter = "protoPayload.resourceName=\"livez\" "
+  }
+
+  exclusions {
+    name = "readyzexclusion"
+    description = "Exclude readyz logs"
+    filter = "protoPayload.resourceName=\"readyz\" "
+  }
+
+  exclusions {
+    name = "metricsexclusion"
+    description = "Exclude metrics logs"
+    filter = "protoPayload.resourceName=\"metrics\" "
+  }
+
+  exclusions {
+    name = "clustermetricsexclusion"
+    description = "Exclude cluster metrics logs"
+    filter = "protoPayload.resourceName=\"core/v1/namespaces/kube-system/configmaps/clustermetrics\" "
+  }
+
   depends_on = [google_pubsub_topic.lacework_topic]
 }
 
@@ -91,6 +116,31 @@ resource "google_logging_organization_sink" "lacework_organization_sink" {
   include_children = true
 
   filter     = local.log_filter
+
+  exclusions {
+    name = "livezexclusion"
+    description = "Exclude livez logs"
+    filter = "protoPayload.resourceName=\"livez\" "
+  }
+
+  exclusions {
+    name = "readyzexclusion"
+    description = "Exclude readyz logs"
+    filter = "protoPayload.resourceName=\"readyz\" "
+  }
+
+  exclusions {
+    name = "metricsexclusion"
+    description = "Exclude metrics logs"
+    filter = "protoPayload.resourceName=\"metrics\" "
+  }
+
+  exclusions {
+    name = "clustermetricsexclusion"
+    description = "Exclude cluster metrics logs"
+    filter = "protoPayload.resourceName=\"core/v1/namespaces/kube-system/configmaps/clustermetrics\" "
+  }
+
   depends_on = [google_pubsub_topic.lacework_topic]
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-gke-audit-log/blob/main/CONTRIBUTING.md
--->

## Summary

The GKE Audit logs that are generated contain a number of extraneous event named logs, these are not used by the Lacework GW and should be filtered out before ingesting into the GW

## How did you test this change?

1) Searched the CBD `QA1_CDB_LPPAUTO_D2D2F0B39DDC376628264C965CD9B4C54FDF6622B72186F4` for the given log entry types to confirm there presence and quantity

2) Created a new GKE Cluster on the Lacework GCP Account

3) Confirmed with the UI Log viewer that the extraneous logs are being generated for this GKE cluster

4) Create a new lacework audit log integration with the new filter changes added, this is found on ` lppauto.qa1.corp.lacework.net`

5) Check on CDB that no entries exist for these extraneous logs for this GKE Cluster

## Issue
https://lacework.atlassian.net/browse/RAIN-39195
