### PR TITLE
fix: fix null members in google_pubsub_topic_iam_binding resource

### DIFF
--- a/examples/organization-level-gke-audit-existing-sink/README.md
+++ b/examples/organization-level-gke-audit-existing-sink/README.md
@@ -1,0 +1,25 @@
+# Integrate GCP Organization GKE Audit logs with Lacework
+The following provides an example of integrating a Google Cloud Project GKE Audit Logs with an existing sink with Lacework.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_gke_audit_log" {
+  source             = "lacework/gke-audit-log/gcp"
+  version            = "~> 0.1"
+  integration_type   = "ORGANIZATION"
+  organization_id    = "123456789"
+  project_id         = "example-project"
+  existing_sink_name = "example-log-sink-name"
+}
+```

--- a/examples/organization-level-gke-audit-existing-sink/main.tf
+++ b/examples/organization-level-gke-audit-existing-sink/main.tf
@@ -1,0 +1,15 @@
+provider "google" {}
+
+provider "lacework" {}
+
+variable "organization_id" {
+  default = "my-organization-id"
+}
+
+module "gcp_organization_level_gke_audit_log" {
+  source             = "../../"
+  integration_type   = "ORGANIZATION"
+  organization_id    = "123456789"
+  project_id         = "example-project"
+  existing_sink_name = "example-log-sink-name"
+}

--- a/examples/organization-level-gke-audit-existing-sink/versions.tf
+++ b/examples/organization-level-gke-audit-existing-sink/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -56,11 +56,15 @@ resource "google_pubsub_topic" "lacework_topic" {
   labels     = merge(var.labels, var.pubsub_topic_labels)
 }
 
+data "google_storage_project_service_account" "lw" {
+  project = local.project_id
+}
+
 resource "google_pubsub_topic_iam_binding" "topic_publisher" {
-  members    = local.logging_sink_writer_identity
-  role       = "roles/pubsub.publisher"
-  project    = local.project_id
-  topic      = google_pubsub_topic.lacework_topic.name
+  members = ["serviceAccount:${data.google_storage_project_service_account.lw.email_address}"]
+  role    = "roles/pubsub.publisher"
+  project = local.project_id
+  topic   = google_pubsub_topic.lacework_topic.name
   depends_on = [google_pubsub_topic.lacework_topic]
 }
 


### PR DESCRIPTION
### Description

The ternary for local `logging_sink_writer_identity` when an existing sink is used, required field members in `google_pubsub_topic_iam_binding` resource is set to null.

The gcp audit log module uses the svc account instead of log sink writer identity -> https://github.com/lacework/terraform-gcp-audit-log/blame/main/main.tf#L184

### Issue
https://lacework.atlassian.net/browse/GROW-1449

### Tests
- [x] TF apply `examples/organization-level-gke-audit-existing-sink/main.tf`


