### PR TITLE
fix: re-implement logging_sink_writer_identity with default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   sink_name = length(var.existing_sink_name) > 0 ? var.existing_sink_name : (
     local.org_integration ? "${var.prefix}-${var.organization_id}-lacework-sink-${random_id.uniq.hex}" : "${var.prefix}-lacework-sink-${random_id.uniq.hex}"
   )
-  logging_sink_writer_identity = length(var.existing_sink_name) > 0 ? null : (
+  logging_sink_writer_identity = length(var.existing_sink_name) > 0 ? ["serviceAccount:${local.service_account_json_key.client_email}"] : (
     (local.org_integration) ? (
       [google_logging_organization_sink.lacework_organization_sink[0].writer_identity]
       ) : (
@@ -61,7 +61,7 @@ data "google_storage_project_service_account" "lw" {
 }
 
 resource "google_pubsub_topic_iam_binding" "topic_publisher" {
-  members = ["serviceAccount:${data.google_storage_project_service_account.lw.email_address}"]
+  members = local.logging_sink_writer_identity
   role    = "roles/pubsub.publisher"
   project = local.project_id
   topic   = google_pubsub_topic.lacework_topic.name


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-gke-audit-log/blob/main/CONTRIBUTING.md
--->

## Summary

This takes the value implemented in https://github.com/lacework/terraform-gcp-gke-audit-log/pull/14 and adds that as the default for logging_sink_writer_identity when a customer brings their own sink

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

relates to GROW-1449