### PR TITLE
feat: Addition of optional user supplied exclusion filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ cloudresourcemanager.googleapis.com
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_existing_sink_name"></a> [existing\_sink\_name](#input\_existing\_sink\_name) | The name of an existing sink to be re-used for this integration | `string` | `""` | no |
+ <a name="input_exclusion_filters"></a> [exclusion\_filters](#input\_exclusion\_filters) | Optional list of exclusion filters that can be passed to the integration to reduce logs | <pre>list(object({<br>  filter = string<br>  name  = string<br>  description = string<br>}))</pre> | `[]` | no |
 | <a name="input_integration_type"></a> [integration\_type](#input\_integration\_type) | Specify the integration type. Can only be PROJECT or ORGANIZATION. Defaults to PROJECT | `string` | `"PROJECT"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Set of labels which will be added to the resources managed by the module | `map(string)` | `{}` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF gke_audit_log"` | no |

--- a/examples/organization-level-gke-audit_with_filters/README.md
+++ b/examples/organization-level-gke-audit_with_filters/README.md
@@ -1,0 +1,37 @@
+# Integrate GCP Organization GKE Audit logs with Lacework
+The following provides an example of integrating a Google Cloud Project GKE Audit Logs with 
+Lacework for analysis.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_gke_audit_log" {
+  source           = "lacework/gke-audit-log/gcp"
+  version          = "~> 0.1"
+  integration_type = "ORGANIZATION"
+  project_id       = "example-project-123"
+  organization_id  = "example-org-123"
+  exclusion_filters = [
+    {
+      name        = "filter-1"
+      filter      = "protoPayload.resourceName=\"readyz\""
+      description = "Test Exclusion Filter 1 for readyz"
+    },
+    {
+      name        = "filter-2"
+      filter      = "protoPayload.resourceName=\"livez\""
+      description = "Test Exclusion Filter 2 for livez"
+    }
+  ]  
+}
+```

--- a/examples/organization-level-gke-audit_with_filters/main.tf
+++ b/examples/organization-level-gke-audit_with_filters/main.tf
@@ -1,0 +1,25 @@
+provider "google" {}
+
+provider "lacework" {}
+
+variable "organization_id" {
+  default = "my-organization-id"
+}
+
+module "gcp_organization_level_gke_audit_log" {
+  source     = "../../"
+  integration_type = "ORGANIZATION"
+  organization_id = var.organization_id
+  exclusion_filters = [
+    {
+      name        = "filter-1"
+      filter      = "protoPayload.resourceName=\"readyz\""
+      description = "Test Exclusion Filter 1 for readyz"
+    },
+    {
+      name        = "filter-2"
+      filter      = "protoPayload.resourceName=\"livez\""
+      description = "Test Exclusion Filter 2 for livez"
+    }
+  ]
+}

--- a/examples/organization-level-gke-audit_with_filters/versions.tf
+++ b/examples/organization-level-gke-audit_with_filters/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/project-level-gke-audit_with_filters/README.md
+++ b/examples/project-level-gke-audit_with_filters/README.md
@@ -1,0 +1,36 @@
+# Integrate GCP Project GKE Audit logs with Lacework
+The following provides an example of integrating a Google Cloud Project GKE Audit Logs with 
+Lacework for analysis.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_project_level_gke_audit" {
+  source           = "lacework/gke-audit-log/gcp"
+  version          = "~> 0.1"
+  integration_type = "PROJECT"
+  project_id       = "example-project-123"
+  exclusion_filters = [
+    {
+      name        = "filter-1"
+      filter      = "protoPayload.resourceName=\"readyz\""
+      description = "Test Exclusion Filter 1 for readyz"
+    },
+    {
+      name        = "filter-2"
+      filter      = "protoPayload.resourceName=\"livez\""
+      description = "Test Exclusion Filter 2 for livez"
+    }
+  ]  
+}
+```

--- a/examples/project-level-gke-audit_with_filters/main.tf
+++ b/examples/project-level-gke-audit_with_filters/main.tf
@@ -1,0 +1,21 @@
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_project_level_gke_audit_log" {
+  source     = "../../"
+  integration_type = "PROJECT"
+  # project_id is set using GOOGLE_PROJECT env var
+  exclusion_filters = [
+    {
+      name        = "filter-1" 
+      filter      = "protoPayload.resourceName=\"readyz\""
+      description = "Test Exclusion Filter 1 for readyz"
+    },
+    {
+      name        = "filter-2" 
+      filter      = "protoPayload.resourceName=\"livez\""
+      description = "Test Exclusion Filter 2 for livez"
+    }
+  ]
+}

--- a/examples/project-level-gke-audit_with_filters/versions.tf
+++ b/examples/project-level-gke-audit_with_filters/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,8 @@ resource "google_logging_project_sink" "lacework_project_sink" {
   unique_writer_identity = true
 
   filter = local.log_filter
-
+  
+  # Standard exclusion filters
   exclusions {
     name        = "livezexclusion"
     description = "Exclude livez logs"
@@ -109,6 +110,16 @@ resource "google_logging_project_sink" "lacework_project_sink" {
     name        = "clustermetricsexclusion"
     description = "Exclude cluster metrics logs"
     filter      = "protoPayload.resourceName=\"core/v1/namespaces/kube-system/configmaps/clustermetrics\" "
+  }
+
+  # Additional user defined filters to exclude
+  dynamic "exclusions" {
+    for_each = var.exclusion_filters      
+    content {
+        name        = exclusions.value["name"]
+        description = exclusions.value["description"]
+        filter      = exclusions.value["filter"]
+    }
   }
 
   depends_on = [google_pubsub_topic.lacework_topic]
@@ -146,6 +157,17 @@ resource "google_logging_organization_sink" "lacework_organization_sink" {
     description = "Exclude cluster metrics logs"
     filter      = "protoPayload.resourceName=\"core/v1/namespaces/kube-system/configmaps/clustermetrics\" "
   }
+
+# Additional user defined filters to exclude
+  dynamic "exclusions" {
+    for_each = var.exclusion_filters      
+    content {
+        name        = exclusions.value["name"]
+        description = exclusions.value["description"]
+        filter      = exclusions.value["filter"]
+    }
+  }
+
 
   depends_on = [google_pubsub_topic.lacework_topic]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,13 @@ variable "pubsub_subscription_labels" {
   default     = {}
   description = "Set of labels which will be added to the subscription"
 }
+
+variable "exclusion_filters" {
+  type = list(object({
+    filter      = string
+    name        = string
+    description = string
+  }))
+  default     = []
+  description = "Set of filters that will be excluded from the audit log"
+} 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-gke-audit-log/blob/main/CONTRIBUTING.md
--->

## Summary
Addition of user defined exclusion logs for the audit log, this will enable each user to define entries in the log that they wish to be excluded, thereby reducing the number of entries.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Added examples with the filters set and without - used `terraform plan` to show that the extra exclusion filters will be created when given as input and not when they are omitted.
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/GROW-1445
<!--
  Include the link to a Jira/Github issue
-->
