### PR TITLE
chore: allow use of gcloud provider version 5

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,4 @@
 formatter: "markdown"
-version: "0.16.0"
+version: ">=0.16.0"
 output:
   file: README.md

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cloudresourcemanager.googleapis.com
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.1 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.4.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.18 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 
@@ -47,7 +47,7 @@ cloudresourcemanager.googleapis.com
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
@@ -56,7 +56,7 @@ cloudresourcemanager.googleapis.com
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lacework_gke_svc_account"></a> [lacework\_gke\_svc\_account](#module\_lacework\_gke\_svc\_account) | lacework/service-account/gcp | ~> 1.0 |
+| <a name="module_lacework_gke_svc_account"></a> [lacework\_gke\_svc\_account](#module\_lacework\_gke\_svc\_account) | lacework/service-account/gcp | ~> 2.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "google_project_service" "required_apis" {
 
 module "lacework_gke_svc_account" {
   source               = "lacework/service-account/gcp"
-  version              = "~> 1.0"
+  version              = "~> 2.0"
   create               = var.use_existing_service_account ? false : true
   service_account_name = local.service_account_name
   project_id           = local.project_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.1"
 
   required_providers {
-    google = ">= 4.4.0, < 5.0.0"
+    google = ">= 4.4.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
## Summary

Allow terraform GCP modules to use Google 5 provider. 

# Testing

Ran integration tests

## Issue

https://lacework.atlassian.net/browse/GROW-2845