### PR TITLE
chore: add var lacework_integration_guid to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cloudresourcemanager.googleapis.com
 
 | Name | Description |
 |------|-------------|
+| <a name="output_lacework_integration_guid"></a> [lacework\_integration\_guid](#output\_lacework\_integration\_guid) | GUID of the created Lacework integration |
 | <a name="output_pubsub_subscription_name"></a> [pubsub\_subscription\_name](#output\_pubsub\_subscription\_name) | The PubSub subscription name |
 | <a name="output_pubsub_topic_name"></a> [pubsub\_topic\_name](#output\_pubsub\_topic\_name) | The PubSub topic name |
 | <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | The Service Account name |

--- a/output.tf
+++ b/output.tf
@@ -23,3 +23,8 @@ output "sink_name" {
   value       = local.sink_name
   description = "The sink name"
 }
+
+output "lacework_integration_guid" {
+  value = length(lacework_integration_gcp_gke_audit_log.default) > 0 ? lacework_integration_gcp_gke_audit_log.default.intg_guid : null
+  description = "GUID of the created Lacework integration"
+}


### PR DESCRIPTION
## Summary

Need lacework_integration_guid variable in output for self deployment project.

## How did you test this change?

Tested on dev space.
<img width="880" height="210" alt="Screenshot 2025-10-14 at 3 59 30 PM" src="https://github.com/user-attachments/assets/50b53219-bccc-4fbd-a967-13da5c77a951" />


## Issue

[<!--
  Include the link to a Jira/Github issue
-->](https://lacework.atlassian.net/jira/software/projects/CAD/boards/373?selectedIssue=CAD-1224)
